### PR TITLE
add freeze_support() for windows multiprocessing

### DIFF
--- a/recipe/entry_point.py
+++ b/recipe/entry_point.py
@@ -3,6 +3,7 @@
 import sys
 
 from concurrent.futures import Executor
+from multiprocessing import freeze_support
 
 # use this for debugging, because ProcessPoolExecutor isn't pdb/ipdb friendly
 class DummyExecutor(Executor):
@@ -12,6 +13,8 @@ class DummyExecutor(Executor):
                 yield func(thing)
 
 if __name__ == '__main__':
+    freeze_support()
+    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.freeze_support
     # Before any more imports, leave cwd out of sys.path for internal 'conda shell.*' commands.
     # see https://github.com/conda/conda/issues/6549
     if len(sys.argv) > 1 and sys.argv[1].startswith('shell.') and sys.path and sys.path[0] == '':


### PR DESCRIPTION
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.freeze_support

This fixes those weird standalone errors we were seeing. `sys.argv` was ending up with multiprocess stuff in it leading to errors like:

```
PS C:\Users\builder\AnacondaTest2> .\newest_conda.exe constructor --extract-conda-pkgs --prefix .
  0%|                                                                                                                                | 0/267 [00:00<?, ?it/s]
usage: newest_conda.exe [-h] [-V] command ...
usage: newest_conda.exe [-h] [-V] command ...
newest_conda.exe: error: argument command: invalid choice: 'parent_pid=2432' (choose from 'clean', 'config', 'create', 'help', 'info', 'init', 'install', 'list', 'package', 'remove', 'uninstall', 'run', 'search', 'update', 'upgrade')
newest_conda.exe: error: argument command: invalid choice: 'parent_pid=2432' (choose from 'clean', 'config', 'create', 'help', 'info', 'init', 'install', 'list', 'package', 'remove', 'uninstall', 'run', 'search', 'update', 'upgrade')
Traceback (most recent call last):
  File "entry_point.py", line 71, in <module>
  File "concurrent\futures\process.py", line 483, in _chain_from_iterable_of_lists
  File "concurrent\futures\_base.py", line 598, in result_iterator
  File "concurrent\futures\_base.py", line 435, in result
  File "concurrent\futures\_base.py", line 384, in __get_result
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.
[2432] Failed to execute script entry_point
```