### PR TITLE
v4.10.3

### DIFF
--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, Anaconda Inc - Anaconda Recipes
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,5 @@
 COPY conda_src\conda\core\path_actions.py "%SP_DIR%\conda\core\path_actions.py"
 COPY conda_src\conda\utils.py "%SP_DIR%\conda\utils.py"
-COPY conda_src\conda\gateways\connection\download.py "%SP_DIR%\conda\gateways\connection\download.py"
 
 :: we need these for noarch packages with entry points to work on windows
 COPY conda_src\conda\shell\cli-%ARCH%.exe entry_point_base.exe

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,9 +5,6 @@ COPY conda_src\conda\gateways\connection\download.py "%SP_DIR%\conda\gateways\co
 :: we need these for noarch packages with entry points to work on windows
 COPY conda_src\conda\shell\cli-%ARCH%.exe entry_point_base.exe
 
-COPY menuinst_src\menuinst\__init__.py "%SP_DIR%\menuinst\__init__.py"
-COPY menuinst_src\menuinst\win32.py "%SP_DIR%\menuinst\win32.py"
-
 :: This is ordinarily installed by the installer itself, but since we are building for a
 :: standalone and have only an env, not an installation, include it here.
 COPY constructor\constructor\nsis\_nsis.py "%PREFIX%\Lib\_nsis.py"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,10 +10,6 @@ fi
 cp conda_src/conda/core/path_actions.py $SP_DIR/conda/core/path_actions.py
 cp conda_src/conda/utils.py $SP_DIR/conda/utils.py
 
-# # patched menuinst files - windows only, so ignore these
-# cp menuinst_src/menuinst/__init__.py ${SP_DIR}/menuinst/__init__.py
-# cp menuinst_src/menuinst/win32.py ${SP_DIR}/menuinst/win32.py
-
 # -F is to create a single file
 # -s strips executables and libraries
 pyinstaller "${_EXTRA_ARGS[@]}" --clean ${_SPEC}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-CONDA_VERSION:
-  - 4.9.0
-python:
-  - 3.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,6 @@ source:
       - conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda..patch
       - conda_patches/0003-Remove-preload_openssl-it-is-so-so-wrong.patch
       # - conda_patches/0004-multiprocessing.set_start_method-fork-for-darwin-on-.patch
-  - git_url: https://github.com/continuumio/menuinst
-    git_tag: 1.4.16
-    folder: menuinst_src
-    patches:
-      - menuinst_patches/0001-Do-not-assume-menuinst-wants-to-operate-on-sys.prefi.patch
-      - menuinst_patches/0002-Allow-menuinst-to-operate-on-non-base-prefix.patch
   - git_url: https://github.com/conda/constructor    # [win]
     git_tag: 3.0.2   # [win]
     folder: constructor   # [win]
@@ -43,6 +37,7 @@ requirements:
     - pyinstaller
     - conda ={{ environ.get("CONDA_VERSION", 4) }}
     - conda-package-handling >=1.7.2
+    - menuinst >=1.4.18  # [win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,22 +8,27 @@
 
 {% set debug = "" %}
 
+{% set version = "4.10.3" %}
+{% set constructor_version = "3.0.2" %}
+{% set python_version = "3.9.7" %}
+
 package:
   name: conda-standalone
-  version: {{ CONDA_VERSION }}
+  version: {{ version }}
 
 source:
   - path: ./
-  - git_url: https://github.com/conda/conda
-    git_tag: {{ CONDA_VERSION }}
+  - url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
+    sha256: 9e83bb20a6b9adc0bd7abccaa4738a71dc04e19a42dc51ad543539c15b2c941a
     folder: conda_src
     patches:
       - conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch
       - conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda..patch
-      - conda_patches/0003-Remove-preload_openssl-it-is-so-so-wrong.patch
+      # upstream since conda v4.9.1 - https://github.com/conda/conda/commit/a55441c3abca68d2dfbacf3f0a81a52dae117eba
+      # - conda_patches/0003-Remove-preload_openssl-it-is-so-so-wrong.patch
       # - conda_patches/0004-multiprocessing.set_start_method-fork-for-darwin-on-.patch
-  - git_url: https://github.com/conda/constructor    # [win]
-    git_tag: 3.0.2   # [win]
+  - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
+    sha256: b46dc3ffb6a7547f84834cc888570446d94ddfd7be832f08a798f55518a30545  # [win]
     folder: constructor   # [win]
 
 build:
@@ -32,10 +37,12 @@ build:
 requirements:
   build:
     - git
+    - patch       # [unix]
+    - m2-patch    # [win]
   host:
-    - python=3.8.5
+    - python ={{ python_version }}
     - pyinstaller
-    - conda ={{ environ.get("CONDA_VERSION", 4) }}
+    - conda ={{ version }}
     - conda-package-handling >=1.7.2
     - menuinst >=1.4.18  # [win]
 
@@ -46,6 +53,9 @@ test:
     - "%PREFIX%\\standalone_conda\\conda.exe -V"  # [win]
     - "%PREFIX%\\standalone_conda\\conda.exe create -y -p env_test zlib tqdm"  # [win]
 
-
 about:
-  summary: Entry point and dependency collection for PyInstaller-based standalone conda
+  home: https://github.com/AnacondaRecipes/conda-standalone-feedstock
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Entry point and dependency collection for PyInstaller-based standalone conda.


### PR DESCRIPTION
Also borrowed some updates from Conda-Forge:
- using git archives instead of tags
- updated version of `menuinst` to include upstreamed patches
- using Python 3.9
- brought versions into meta.yaml

I did not update the `constructor` version as it seemed like there were some patches that might be needed: see [Conda-Forge PR](https://github.com/conda-forge/conda-standalone-feedstock/pull/18).