### PR TITLE
Restore menuinst and patches.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,6 +4,9 @@ COPY conda_src\conda\utils.py "%SP_DIR%\conda\utils.py"
 :: we need these for noarch packages with entry points to work on windows
 COPY conda_src\conda\shell\cli-%ARCH%.exe entry_point_base.exe
 
+COPY menuinst_src\menuinst\__init__.py "%SP_DIR%\menuinst\__init__.py"
+COPY menuinst_src\menuinst\win32.py "%SP_DIR%\menuinst\win32.py"
+
 :: This is ordinarily installed by the installer itself, but since we are building for a
 :: standalone and have only an env, not an installation, include it here.
 COPY constructor\constructor\nsis\_nsis.py "%PREFIX%\Lib\_nsis.py"

--- a/recipe/menuinst_patches/0002-Allow-menuinst-to-operate-on-non-base-prefix.patch
+++ b/recipe/menuinst_patches/0002-Allow-menuinst-to-operate-on-non-base-prefix.patch
@@ -8,19 +8,19 @@ Subject: [PATCH 2/2] Allow menuinst to operate on non base prefix
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/menuinst/win32.py b/menuinst/win32.py
-index f95abe2..a8ffb8f 100644
+index 67f222a..cedd47c 100644
 --- a/menuinst/win32.py
 +++ b/menuinst/win32.py
 @@ -170,7 +170,7 @@ def substitute_env_variables(text, dir):
- 
+
      for a, b in (
          (u'${PREFIX}', env_prefix),
 -        (u'${ROOT_PREFIX}', unicode_root_prefix),
 +        (u'${ROOT_PREFIX}', to_unicode(env_prefix)),
+         (u'${DISTRIBUTION_NAME}', os.path.split(unicode_root_prefix)[-1].capitalize()),
          (u'${PYTHON_SCRIPTS}',
            os.path.normpath(join(env_prefix, u'Scripts')).replace(u"\\", u"/")),
-         (u'${MENU_DIR}', join(env_prefix, u'Menu')),
-@@ -284,6 +284,7 @@ class ShortCut(object):
+@@ -285,6 +285,7 @@ class ShortCut(object):
          args = []
          fix_win_slashes = [0]
          prefix = self.menu.prefix.replace('/', '\\')

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@
 
 {% set version = "4.10.3" %}
 {% set constructor_version = "3.0.2" %}
-{% set python_version = "3.9.7" %}
+{% set python_version = "3.9" %}
 
 package:
   name: conda-standalone
@@ -27,12 +27,18 @@ source:
       # upstream since conda v4.9.1 - https://github.com/conda/conda/commit/a55441c3abca68d2dfbacf3f0a81a52dae117eba
       # - conda_patches/0003-Remove-preload_openssl-it-is-so-so-wrong.patch
       # - conda_patches/0004-multiprocessing.set_start_method-fork-for-darwin-on-.patch
+  - git_url: https://github.com/conda/menuinst
+    git_tag: 1.4.17
+    folder: menuinst_src
+    patches:
+      - menuinst_patches/0001-Do-not-assume-menuinst-wants-to-operate-on-sys.prefi.patch
+      - menuinst_patches/0002-Allow-menuinst-to-operate-on-non-base-prefix.patch
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
     sha256: b46dc3ffb6a7547f84834cc888570446d94ddfd7be832f08a798f55518a30545  # [win]
     folder: constructor   # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -45,7 +51,6 @@ requirements:
     - pyinstaller
     - conda ={{ version }}
     - conda-package-handling >=1.7.2
-    - menuinst >=1.4.18  # [win]
 
 test:
   commands:


### PR DESCRIPTION
Revert the changes to `menuinst` and bump to v1.4.17 in order to use `${DISTRIBUTION_NAME}`.

Addresses some issues with the installer shortcuts.