### PR TITLE
 Add patch to remove capitalization of DISTRIBUTION_NAME

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 channels:
-  paulyim: prompt_name
+  - paulyim
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  paulyim: prompt_name
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 channels:
-  - paulyim
+  - c3i_test2
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  - c3i_test2
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,7 @@ COPY conda_src\conda\utils.py "%SP_DIR%\conda\utils.py"
 COPY conda_src\conda\shell\cli-%ARCH%.exe entry_point_base.exe
 
 COPY menuinst_src\menuinst\__init__.py "%SP_DIR%\menuinst\__init__.py"
+COPY menuinst_src\menuinst\win32.py "%SP_DIR%\menuinst\win32.py"
 
 :: This is ordinarily installed by the installer itself, but since we are building for a
 :: standalone and have only an env, not an installation, include it here.

--- a/recipe/menuinst_patches/0004-distribution-name-subst.patch
+++ b/recipe/menuinst_patches/0004-distribution-name-subst.patch
@@ -1,0 +1,13 @@
+diff --git a/menuinst/win32.py b/menuinst/win32.py
+index 6aabd93..370909e 100644
+--- a/menuinst/win32.py
++++ b/menuinst/win32.py
+@@ -171,7 +171,7 @@ def substitute_env_variables(text, dir):
+     for a, b in (
+         (u'${PREFIX}', env_prefix),
+         (u'${ROOT_PREFIX}', root_prefix),
+-        (u'${DISTRIBUTION_NAME}', os.path.split(root_prefix)[-1].capitalize()),
++        (u'${DISTRIBUTION_NAME}', os.path.split(root_prefix)[-1]),
+         (u'${PYTHON_SCRIPTS}',
+           os.path.normpath(join(env_prefix, u'Scripts')).replace(u"\\", u"/")),
+         (u'${MENU_DIR}', join(env_prefix, u'Menu')),

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ source:
     folder: menuinst_src                                                                    # [win]
     patches:                                                                                # [win]
       - menuinst_patches/0003-root-prefix-to-prefix.patch                                   # [win]
+      - menuinst_patches/0004-distribution-name-subst.patch                                 # [win]
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
     sha256: b000dde0ac8641c92f7342362173968505d4e85845be37655b5b9221cb65f3a8  # [win]
     folder: constructor  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     folder: constructor  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,10 @@ test:
 
 about:
   home: https://github.com/AnacondaRecipes/conda-standalone-feedstock
+  dev_url: https://github.com/AnacondaRecipes/conda-standalone-feedstock
+  doc_url: https://github.com/AnacondaRecipes/conda-standalone-feedstock/blob/master/README.md
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: Entry point and dependency collection for PyInstaller-based standalone conda.
+  description: Standalone version of conda to bootstrap conda for Miniconda and Anaconda Distribution.


### PR DESCRIPTION
Restore old Miniconda behavior by adding the installation directory to prompt name.

Jira ticket: https://anaconda.atlassian.net/browse/PKG-1010