### PR TITLE
Update to v24.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
-{% set version = "24.1.2" %}
+{% set version = "24.3.0" %}
 {% set conda_libmamba_solver_version = "24.1.0" %}
-{% set libmambapy_version = "1.5.6" %}
-{% set constructor_version = "3.6.0" %}
-{% set python_version = "3.10.13" %}
+{% set libmambapy_version = "1.5.8" %}
+{% set constructor_version = "3.7.0" %}
+{% set python_version = "3.10.14" %}
 
 package:
   name: conda-standalone
@@ -10,15 +10,15 @@ package:
 
 source:
   - url: https://github.com/conda/conda-standalone/archive/{{ version }}.tar.gz
-    sha256: b45f14013e843fa4f89a51a4f3498331f7aa2717c6a6f11126d5327749a5d36b
+    sha256: 1330525275f31dba008f564f83466b4c262601c09608e66cb08b6ea3c01decd2
   - url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
-    sha256: 6bc4f1f72a0edddefa10e0667d6ab2eb2f1956919a59508bf3bf6c001bf7a6e8
+    sha256: 92211ae60037bceb452e3f03183be29dcecc62c7826661cff6eaeb41cb216208
     folder: conda_src
     patches:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch"
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch"
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: d47e6f805337de70a72dea62999853361fbf558e2fbf3a9016c7a007be82ff46  # [win]
+    sha256: e84de1d7db3dbd394c03fa0e966bd293729307b9de0c8733ed7189f422a4b5b5 # [win]
     folder: constructor_src  # [win]
 
 build:


### PR DESCRIPTION
conda-standalone 24.3.0

**Destination channel:** defaults

### Links

- [PKG-4727](https://anaconda.atlassian.net/browse/PKG-4727) 
- [Upstream repository](https://github.com/conda/conda-standalone/)
- [Upstream changelog/diff](https://github.com/conda/conda-standalone/blob/main/CHANGELOG.md#2430-2024-05-07)

### Explanation of changes:

- Update to conda 24.3.0, libmamba 1.5.8, constructor 3.7.0, Python 3.10.14.

[PKG-4727]: https://anaconda.atlassian.net/browse/PKG-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ