### PR TITLE
Update to version 24.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: constructor_src  # [win]
 
 build:
-  number: 1
+  number: 0
   ignore_run_exports:
     - '*'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
-{% set version = "24.3.0" %}
+{% set version = "24.4.0" %}
 {% set conda_libmamba_solver_version = "24.1.0" %}
 {% set libmambapy_version = "1.5.8" %}
-{% set constructor_version = "3.7.0" %}
-{% set python_version = "3.10.14" %}
+{% set constructor_version = "3.8.0" %}
+{% set python_version = "3.11.9" %}
 
 package:
   name: conda-standalone
@@ -10,15 +10,15 @@ package:
 
 source:
   - url: https://github.com/conda/conda-standalone/archive/{{ version }}.tar.gz
-    sha256: 1330525275f31dba008f564f83466b4c262601c09608e66cb08b6ea3c01decd2
+    sha256: c2e54c6493150bfc7242895159ff82de445e420e0379a50e61bc8a491e9c0397
   - url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
-    sha256: 92211ae60037bceb452e3f03183be29dcecc62c7826661cff6eaeb41cb216208
+    sha256: 6e0f3fb26a39f27c3c8fb1baf76ab85010b552e39ed145b4a3a2795ad344105d
     folder: conda_src
     patches:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch"
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch"
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: e84de1d7db3dbd394c03fa0e966bd293729307b9de0c8733ed7189f422a4b5b5 # [win]
+    sha256: b10b675745e0d709d3e4a9106fba8e9169e6a940ab873a5ad02593dee9cf2fb4 # [win]
     folder: constructor_src  # [win]
 
 build:


### PR DESCRIPTION
conda-standalone 24.4.0

**Destination channel:** defaults

### Links

- [PKG-4816](https://anaconda.atlassian.net/browse/PKG-4816) 
- [Upstream repository](https://github.com/conda/conda-standalone/)
- [Upstream changelog/diff](https://github.com/conda/conda-standalone/blob/main/CHANGELOG.md#2440-2024-05-15)

### Explanation of changes:

- Update `conda-standalone` to v24.4.0
- Update `python` to v3.11.9
- Update `constructor` to v3.8.0


[PKG-4816]: https://anaconda.atlassian.net/browse/PKG-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ