### PR TITLE
Update to v24.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
-{% set version = "24.4.0" %}
+{% set version = "24.5.0" %}
 {% set conda_libmamba_solver_version = "24.1.0" %}
 {% set libmambapy_version = "1.5.8" %}
 {% set constructor_version = "3.8.0" %}
+{% set menuinst_lower_bound = "2.1.1" %}
 {% set python_version = "3.11.9" %}
 
 package:
@@ -12,13 +13,13 @@ source:
   - url: https://github.com/conda/conda-standalone/archive/{{ version }}.tar.gz
     sha256: c2e54c6493150bfc7242895159ff82de445e420e0379a50e61bc8a491e9c0397
   - url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
-    sha256: 6e0f3fb26a39f27c3c8fb1baf76ab85010b552e39ed145b4a3a2795ad344105d
+    sha256: 4a571495f08d49127b9ae28d8b8cb30bb055d061c189d8ef8c5682b26b6bde24
     folder: conda_src
     patches:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch"
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch"
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: b10b675745e0d709d3e4a9106fba8e9169e6a940ab873a5ad02593dee9cf2fb4 # [win]
+    sha256: 0a0ca62e6bee9d6321f410ff88e24201de9d83bf38682d4911813c06b8a611a6 # [win]
     folder: constructor_src  # [win]
 
 build:
@@ -33,8 +34,9 @@ requirements:
     - pyinstaller
     - python ={{ python_version }}
     - conda ={{ version }}
-    - conda-package-handling >=1.6
-    - menuinst >=2.0.2
+    - conda-package-handling >=2.3.0
+    - conda-package-streaming >=0.9.0
+    - menuinst >={{ menuinst_lower_bound }}
     - conda-libmamba-solver ={{ conda_libmamba_solver_version }}
     - libmambapy ={{ libmambapy_version }}
     - archspec >=0.2.3
@@ -44,7 +46,7 @@ requirements:
 test:
   requires:
     - pytest
-    - menuinst >=2
+    - menuinst >={{ menuinst_lower_bound }}
   source_files:
     - tests
   commands:


### PR DESCRIPTION
conda-standalone 24.5.0

**Destination channel:** defaults

### Links

- [{ticket_number}]() 
- [Upstream repository](https://github.com/conda/conda-standalone)
- [Upstream changelog/diff](https://github.com/conda/conda-standalone/blob/main/CHANGELOG.md#2450-2024-06-13)

### Explanation of changes:

- Update to v24.5.0