### PR TITLE
Update to v24.7.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-content_signing:
-  win-64: False

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+content_signing:
+  win-64: False

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   build:
     - patch  # [not win]
     - m2-patch  # [win]
-    - pefile ==2022.5.30  # [win]
+    - pefile ==2023.2.7  # [win]
     - pyinstaller ==5.13.2
     - python ={{ python_version }}
     - conda ={{ conda_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,25 @@
-{% set version = "24.5.0" %}
-{% set conda_libmamba_solver_version = "24.1.0" %}
+{% set conda_version = "24.7.1" %}
+{% set conda_libmamba_solver_version = "24.7.0" %}
 {% set libmambapy_version = "1.5.8" %}
-{% set constructor_version = "3.8.0" %}
-{% set menuinst_lower_bound = "2.1.1" %}
+{% set constructor_version = "3.9.2" %}
+{% set menuinst_lower_bound = "2.1.2" %}
 {% set python_version = "3.11.9" %}
 
 package:
   name: conda-standalone
-  version: {{ version }}
+  version: {{ conda_version }}
 
 source:
-  - url: https://github.com/conda/conda-standalone/archive/{{ version }}.tar.gz
-    sha256: 73d059cf28b02ff7424177abcecd0084111da3e75aec8c5dab1af81261120a0d
-  - url: https://github.com/conda/conda/archive/{{ version }}.tar.gz
-    sha256: 4a571495f08d49127b9ae28d8b8cb30bb055d061c189d8ef8c5682b26b6bde24
+  - url: https://github.com/conda/conda-standalone/archive/{{ conda_version }}.tar.gz
+    sha256: 658c00fab9a117c4712592cf6891d752cfd404dd3c0afbb9bfc51514f884ceba
+  - url: https://github.com/conda/conda/archive/{{ conda_version }}.tar.gz
+    sha256: 8590451bc4527ec6a2ca48242c940f2e6d5ea60972702d5671ac2299fab63e6f
     folder: conda_src
     patches:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch"
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch"
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: 0a0ca62e6bee9d6321f410ff88e24201de9d83bf38682d4911813c06b8a611a6 # [win]
+    sha256: 0ea4f6d563a53ebb03475dc6d2d88d3ab01be4e9d291fd276c79315aa92e5114  # [win]
     folder: constructor_src  # [win]
 
 build:
@@ -33,7 +33,7 @@ requirements:
     - m2-patch  # [win]
     - pyinstaller
     - python ={{ python_version }}
-    - conda ={{ version }}
+    - conda ={{ conda_version }}
     - conda-package-handling >=2.3.0
     - conda-package-streaming >=0.9.0
     - menuinst >={{ menuinst_lower_bound }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
   build:
     - patch  # [not win]
     - m2-patch  # [win]
+    - pefile ==2022.5.30  # [win]
     - pyinstaller
     - python ={{ python_version }}
     - conda ={{ conda_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   build:
     - patch  # [not win]
     - m2-patch  # [win]
-    - pefile ==2023.2.7  # [win]
+    # Signing currently fails with pyinstaller 6.*
     - pyinstaller ==5.13.2
     - python ={{ python_version }}
     - conda ={{ conda_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - patch  # [not win]
     - m2-patch  # [win]
     - pefile ==2022.5.30  # [win]
-    - pyinstaller
+    - pyinstaller ==5.13.2
     - python ={{ python_version }}
     - conda ={{ conda_version }}
     - conda-package-handling >=2.3.0


### PR DESCRIPTION
conda-standalone 24.7.1

**Destination channel:** defaults

### Links

- [PKG-5512](https://anaconda.atlassian.net/browse/PKG-5512) 
- [Upstream repository](https://github.com/conda/conda-standalone/)
- [Upstream changelog/diff](https://github.com/conda/conda-standalone/blob/main/CHANGELOG.md#2471-2024-08-13)

### Explanation of changes:

- Update `conda-standalone` to v24.7.1
- Change `version` jinja variable to `conda_version` to sync with upstream recipe


[PKG-5512]: https://anaconda.atlassian.net/browse/PKG-5512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ