### PR TITLE
Update to v24.9.2

### DIFF
--- a/recipe/.condarc
+++ b/recipe/.condarc
@@ -1,0 +1,2 @@
+channels:
+  - defaults

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,6 +6,8 @@ RENAME "%SP_DIR%\conda\utils.py" utils.py.bak || goto :error
 COPY conda_src\conda\utils.py "%SP_DIR%\conda\utils.py" || goto :error
 RENAME "%SP_DIR%\conda\deprecations.py" deprecations.py.bak || goto :error
 COPY conda_src\conda\deprecations.py "%SP_DIR%\conda\deprecations.py" || goto :error
+RENAME "%SP_DIR%\conda\base\constants.py" constants.py.bak || goto :error
+COPY conda_src\conda\base\constants.py "%SP_DIR%\conda\base\constants.py" || goto :error
 
 :: we need these for noarch packages with entry points to work on windows
 COPY "conda_src\conda\shell\cli-%ARCH%.exe" entry_point_base.exe || goto :error

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,7 @@ set -euxo pipefail
 
 # patched conda files
 # new files in patches need to be added here
-for fname in "core/path_actions.py" "utils.py" "deprecations.py"; do
+for fname in "core/path_actions.py" "utils.py" "deprecations.py" "base/constants.py"; do
   mv "$SP_DIR/conda/${fname}" "$SP_DIR/conda/${fname}.bak"
   cp "conda_src/conda/${fname}" "$SP_DIR/conda/${fname}"
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch"
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0003-Restrict-search-paths.patch"
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: 0ea4f6d563a53ebb03475dc6d2d88d3ab01be4e9d291fd276c79315aa92e5114  # [win]
+    sha256: c88640ca1dcb93784cf754a16c53a098633808653aa52965c909a967b84815b9  # [win]
     folder: constructor_src  # [win]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set conda_version = "24.9.2" %}
 {% set conda_libmamba_solver_version = "24.9.0" %}
-{% set libmambapy_version = "1.5.10" %}
+{% set libmambapy_version = "1.5.8" %}
 {% set constructor_version = "3.9.3" %}
 {% set menuinst_lower_bound = "2.1.2" %}
 {% set python_version = "3.12.7" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set libmambapy_version = "1.5.8" %}
 {% set constructor_version = "3.9.3" %}
 {% set menuinst_lower_bound = "2.1.2" %}
-{% set python_version = "3.12.7" %}
+{% set python_version = "3.11.10" %}
 
 package:
   name: conda-standalone
@@ -34,7 +34,8 @@ requirements:
   build:
     - patch  # [not win]
     - m2-patch  # [win]
-    - pyinstaller
+    # Signing currently fails with pyinstaller 6.*
+    - pyinstaller ==5.13.2
     - python ={{ python_version }}
     - conda ={{ conda_version }}
     - conda-package-handling >=2.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,7 @@ requirements:
   build:
     - patch  # [not win]
     - m2-patch  # [win]
-    # Signing currently fails with pyinstaller 6.*
-    - pyinstaller ==5.13.2
+    - pyinstaller
     - python ={{ python_version }}
     - conda ={{ conda_version }}
     - conda-package-handling >=2.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
-{% set conda_version = "24.7.1" %}
-{% set conda_libmamba_solver_version = "24.7.0" %}
-{% set libmambapy_version = "1.5.8" %}
-{% set constructor_version = "3.9.2" %}
+{% set conda_version = "24.9.2" %}
+{% set conda_libmamba_solver_version = "24.9.0" %}
+{% set libmambapy_version = "1.5.10" %}
+{% set constructor_version = "3.9.3" %}
 {% set menuinst_lower_bound = "2.1.2" %}
-{% set python_version = "3.11.9" %}
+{% set python_version = "3.12.7" %}
 
 package:
   name: conda-standalone
@@ -11,13 +11,14 @@ package:
 
 source:
   - url: https://github.com/conda/conda-standalone/archive/{{ conda_version }}.tar.gz
-    sha256: 658c00fab9a117c4712592cf6891d752cfd404dd3c0afbb9bfc51514f884ceba
+    sha256: 551998dc34f1fcf0ed509b881d62838bb2396e3abad37c9d4b4970f53a487533
   - url: https://github.com/conda/conda/archive/{{ conda_version }}.tar.gz
-    sha256: 8590451bc4527ec6a2ca48242c940f2e6d5ea60972702d5671ac2299fab63e6f
+    sha256: 7323ed0ae876f9d86f04c61ae01f53095adc570df27d9c375266df2745d51b8b
     folder: conda_src
     patches:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch"
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch"
+      - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0003-Restrict-search-paths.patch"
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
     sha256: 0ea4f6d563a53ebb03475dc6d2d88d3ab01be4e9d291fd276c79315aa92e5114  # [win]
     folder: constructor_src  # [win]
@@ -26,6 +27,8 @@ build:
   number: 0
   ignore_run_exports:
     - '*'
+  script_env:
+    - PYINSTALLER_CONDARC_DIR={{ RECIPE_DIR }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set libmambapy_version = "1.5.8" %}
 {% set constructor_version = "3.9.3" %}
 {% set menuinst_lower_bound = "2.1.2" %}
-{% set python_version = "3.12.7" %}
+{% set python_version = "3.11.10" %}
 
 package:
   name: conda-standalone

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set libmambapy_version = "1.5.8" %}
 {% set constructor_version = "3.9.3" %}
 {% set menuinst_lower_bound = "2.1.2" %}
-{% set python_version = "3.11.10" %}
+{% set python_version = "3.12.7" %}
 
 package:
   name: conda-standalone

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ test:
   requires:
     - pytest
     - menuinst >={{ menuinst_lower_bound }}
+    - ruamel.yaml
   source_files:
     - tests
   commands:


### PR DESCRIPTION
conda-standalone 24.9.2

**Destination channel:** defaults

### Links

- [PKG-6033](https://anaconda.atlassian.net/browse/PKG-6033) 
- [Upstream repository](https://github.com/conda/conda-standalone/)
- [Upstream changelog/diff](https://github.com/conda/conda-standalone/blob/main/CHANGELOG.md#2492-2024-10-30)

### Explanation of changes:

- Update conda-standalone to version 24.9.2.
- Add `.condarc` file to point to `defaults` since automatically pointing to `defaults` is deprecated
- `libmambapy` was pinned to 1.5.8 because 1.5.10 is not available on defaults.
- We stick with python 3.11 because signing fails with python 3.12 on Windows.

[PKG-6033]: https://anaconda.atlassian.net/browse/PKG-6033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ