### PR TITLE
Add patch to fix PATH order

### DIFF
--- a/recipe/0001-fix-path-prepend.patch
+++ b/recipe/0001-fix-path-prepend.patch
@@ -1,0 +1,14 @@
+diff --git a/src/conda_constructor/windows/path.py b/src/conda_constructor/windows/path.py
+index bb48d26..0ee95a8 100644
+--- a/src/conda_constructor/windows/path.py
++++ b/src/conda_constructor/windows/path.py
+@@ -133,6 +133,9 @@ def add_remove_path(
+             prefix / "Library" / "bin",
+             prefix / "Scripts",
+         ]
++        # Reverse the prefixes when prepending or they will be added in reverse order
++        if not append:
++            prefixes.reverse()
+     else:
+         prefixes = [prefix]
+     if add is not None:

--- a/recipe/0001-fix-path-prepend.patch
+++ b/recipe/0001-fix-path-prepend.patch
@@ -1,8 +1,24 @@
 diff --git a/src/conda_constructor/windows/path.py b/src/conda_constructor/windows/path.py
-index bb48d26..0ee95a8 100644
+index bb48d26..93e7bd9 100644
 --- a/src/conda_constructor/windows/path.py
 +++ b/src/conda_constructor/windows/path.py
-@@ -133,6 +133,9 @@ def add_remove_path(
+@@ -105,11 +105,14 @@ def _remove_from_path(prefixes: list[Path], user_or_system: Literal["user", "sys
+     if not reg_value:
+         return
+     paths = reg_value.split(os.pathsep)
++    npaths = len(paths)
+     for prefix in prefixes:
+         p = _find_in_path(prefix, paths, value_type)
+         if p == -1:
+-            return
++            continue
+         del paths[p]
++    if npaths == len(paths):
++        return
+     registry.set(key, named_value="Path", value=os.pathsep.join(paths), value_type=value_type)
+     _broadcast_environment_settings_change()
+ 
+@@ -133,6 +136,9 @@ def add_remove_path(
              prefix / "Library" / "bin",
              prefix / "Scripts",
          ]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ package:
 source:
   - url: https://github.com/conda/conda-standalone/archive/refs/tags/{{ version }}.tar.gz
     sha256: ef0453524062e76eaa30b41fb249a54c627761138ca738c0343a8cafd78d975b
+    patches:
+      - 0001-fix-path-prepend.patch
   - url: https://github.com/conda/conda/releases/download/{{ conda_version }}/conda-{{ conda_version }}.tar.gz
     sha256: 62aad5c046936b07e3ea44d6d908f2d94b427049420332def421e9c72ff3961e
     folder: conda_src
@@ -23,7 +25,7 @@ source:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0004-Fix-conda-run.patch"
 
 build:
-  number: 0
+  number: 1
   string: "h{{ PKG_HASH }}_single_{{ PKG_BUILDNUM }}"  # [variant != 'onedir']
   string: "h{{ PKG_HASH }}_onedir_{{ PKG_BUILDNUM }}"  # [variant == 'onedir']
   detect_binary_files_with_prefix: False  # [variant == 'onedir']


### PR DESCRIPTION
conda-standalone 25.11.0

**Destination channel:** defaults

### Links

- [PKG-11643](https://anaconda.atlassian.net/browse/PKG-11643) 
- [Upstream repository](https://github.com/conda/conda-standalone)

### Explanation of changes:

- There is a bug in the `constructor` plug-in that prepends the paths in the wrong order to the Windows `PATH` variable. This patch fixes it.


[PKG-11643]: https://anaconda.atlassian.net/browse/PKG-11643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ