### PR TITLE
Update to v26.3.2.post1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/conda/conda-standalone/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 4ceca0a7466465f27e0bc9c32af57ec2d3be7d05ef3a4d64138ae1a0862ac021
+  - url: https://github.com/conda/conda-standalone/archive/refs/tags/{{ version }}.post1.tar.gz
+    sha256: 158c1ee18974b9907ebf3c0c1e4ddcdf1b7b003fa0dbc7896d9df7618286270e
   - url: https://github.com/conda/conda/releases/download/{{ conda_version }}/conda-{{ conda_version }}.tar.gz
     sha256: b5f5c1d4068a6582816d223733993eff354d55ec762ac555b49fdb8de07050c6
     folder: conda_src


### PR DESCRIPTION
conda-standalone 26.3.2.post1

**Destination channel:** defaults

### Links

- [PKG-14484](https://anaconda.atlassian.net/browse/PKG-14484) 
- [Upstream repository](https://github.com/conda/conda-standalone/)
- [Upstream changelog/diff](https://github.com/conda/conda-standalone/blob/main/CHANGELOG.md#2632post1-2026-05-01)

[PKG-14484]: https://anaconda.atlassian.net/browse/PKG-14484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ