### PR TITLE
Prepare 26.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "26.5.2" %}
 {% set conda_version = "26.5.2" %}
 {% set conda_libmamba_solver_version = "26.4.2" %}
-{% set libmambapy_version = "2.8.0" %}
+{% set libmambapy_version = "2.3.2" %}
 {% set constructor_lower_bound = "3.15.2" %}
 {% set menuinst_lower_bound = "2.5.0" %}
 {% set python_version = "3.13.13" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
-{% set version = "26.3.2.post1" %}
-{% set conda_version = "26.3.2" %}
-{% set conda_libmamba_solver_version = "26.4.0" %}
-{% set libmambapy_version = "2.3.2" %}
+{% set version = "26.5.2" %}
+{% set conda_version = "26.5.2" %}
+{% set conda_libmamba_solver_version = "26.4.2" %}
+{% set libmambapy_version = "2.8.0" %}
 {% set constructor_lower_bound = "3.15.2" %}
-{% set menuinst_lower_bound = "2.4.1" %}
+{% set menuinst_lower_bound = "2.5.0" %}
 {% set python_version = "3.13.13" %}
 
 package:
@@ -12,9 +12,9 @@ package:
 
 source:
   - url: https://github.com/conda/conda-standalone/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 158c1ee18974b9907ebf3c0c1e4ddcdf1b7b003fa0dbc7896d9df7618286270e
+    sha256: 12323fb53979e00243b87d9391b2da4b8eb05b7a0abc988501dd719df41d7b29
   - url: https://github.com/conda/conda/releases/download/{{ conda_version }}/conda-{{ conda_version }}.tar.gz
-    sha256: b5f5c1d4068a6582816d223733993eff354d55ec762ac555b49fdb8de07050c6
+    sha256: 4c0227d37f7a54b332fea5b12ba855252ca80fbc1452bb66522eb74084039be5
     folder: conda_src
     patches:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch"


### PR DESCRIPTION
`conda-standalone` `26.5.2`

**Destination channel:** defaults

### Links

- [PKG-15263](https://anaconda.atlassian.net/browse/PKG-15263) 
- [Upstream repository](https://github.com/conda/conda-standalone)
- [Upstream changelog/diff](4c0227d37f7a54b332fea5b12ba855252ca80fbc1452bb66522eb74084039be5)


[PKG-15263]: https://anaconda.atlassian.net/browse/PKG-15263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ