### PR TITLE
Prepare 26.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
-{% set version = "26.5.2" %}
-{% set conda_version = "26.5.2" %}
-{% set conda_libmamba_solver_version = "26.4.2" %}
+{% set version = "26.7.0" %}
+{% set conda_version = "26.7.0" %}
+{% set conda_libmamba_solver_version = "26.7.0" %}
 {% set libmambapy_version = "2.3.2" %}
-{% set constructor_lower_bound = "3.15.2" %}
-{% set menuinst_lower_bound = "2.5.0" %}
-{% set python_version = "3.13.13" %}
+{% set constructor_lower_bound = "3.15.3" %}
+{% set menuinst_lower_bound = "2.5.2" %}
+{% set python_version = "3.13.14" %}
 
 package:
   name: conda-standalone
@@ -12,9 +12,9 @@ package:
 
 source:
   - url: https://github.com/conda/conda-standalone/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 12323fb53979e00243b87d9391b2da4b8eb05b7a0abc988501dd719df41d7b29
+    sha256: 77d94e06f05c64c7f5218a4070f9ef2cd185ec170a13a407b5efc61be78989ac
   - url: https://github.com/conda/conda/releases/download/{{ conda_version }}/conda-{{ conda_version }}.tar.gz
-    sha256: 4c0227d37f7a54b332fea5b12ba855252ca80fbc1452bb66522eb74084039be5
+    sha256: d15d9735d7b46a2c54757b2844b66e71f62441daff36baef070f3cb3a3b257c1
     folder: conda_src
     patches:
       - "{{ SRC_DIR | replace('\\', '/') }}/src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch"


### PR DESCRIPTION
`conda-standalone` `26.7.0`

**Destination channel:** defaults

### Links

- [PKG-17015](https://anaconda.atlassian.net/browse/PKG-17015) 
- [Upstream repository](https://github.com/conda/conda-standalone)
- [Upstream changelog/diff](https://github.com/conda/conda-standalone/blob/main/CHANGELOG.md#2670-2026-08-04)


[PKG-17015]: https://anaconda.atlassian.net/browse/PKG-17015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ